### PR TITLE
PBIS configuration tasks

### DIFF
--- a/join-domain/elx/pbis-config.sls
+++ b/join-domain/elx/pbis-config.sls
@@ -14,6 +14,7 @@
 #
 #################################################################
 {%- set pbisBinDir = salt['pillar.get']('join-domain:linux:install_bin_dir') %}
+{%- set domfqdn = salt['pillar.get']('join-domain:linux:ad_domain_fqdn') %}
 {%- set pbisUserHome = [ 'HomeDirTemplate', 'Local_HomeDirTemplate' ] %}
 {%- set pbisUserShell = [ 'LoginShellTemplate', 'Local_LoginShellTemplate' ] %}
 {%- set loginHome = '%H/%D/%U' %}
@@ -34,5 +35,19 @@ PBIS-config-uHome:
 {%- for uHome in pbisUserHome %}
         {{ pbisBinDir }}/bin/config {{ uHome }} "{{ loginHome }}"
 {%- endfor %}
+    - require:
+      - cmd: PBIS-installsh
+
+PBIS-config-TrustIgnore:
+  cmd.run:
+    - name: |
+        {{ pbisBinDir }}/bin/config DomainManagerIgnoreAllTrusts true
+    - require:
+      - cmd: PBIS-installsh
+
+PBIS-config-TrustList:
+  cmd.run:
+    - name: |
+        {{ pbisBinDir }}/bin/config DomainManagerIncludeTrustsList {{ domfqdn }}
     - require:
       - cmd: PBIS-installsh

--- a/join-domain/elx/pbis-config.sls
+++ b/join-domain/elx/pbis-config.sls
@@ -1,0 +1,38 @@
+# Customize the PBIS configuration to assure a more sane,
+# post-join behavior:
+# * Set 'LoginShellTemplate' and 'Local_LoginShellTemplate' to
+#   desired (friendlier) value ("/bin/bash" - PBIS defaults to
+#   "/bin/sh")
+# * Set 'HomeDirTemplate' and 'Local_HomeDirTemplate' to flatter
+#   default value ("/home/<DOMAIN>/${USER}" - PBIS sets to
+#   "/home/local/<DOMAIN>/${USER}")
+# * Set 'DomainManagerIgnoreAllTrusts' to "true" to prevent 
+#   spurious service-faults in multi-domain forrests.
+# * Set 'DomainManagerIncludeTrustsList' to match domain FQDN. 
+#   This setting necessary due to setting of the
+#   'DomainManagerIgnoreAllTrusts' value to "true"
+#
+#################################################################
+{%- set pbisBinDir = salt['pillar.get']('join-domain:linux:install_bin_dir') %}
+{%- set pbisUserHome = [ 'HomeDirTemplate', 'Local_HomeDirTemplate' ] %}
+{%- set pbisUserShell = [ 'LoginShellTemplate', 'Local_LoginShellTemplate' ] %}
+{%- set loginHome = '%H/%D/%U' %}
+{%- set loginShell = '/bin/bash' %}
+
+PBIS-config-iShell:
+  cmd.run:
+    - name: |
+{%- for userShell in pbisUserShell %}
+        {{ pbisBinDir }}/bin/config {{ userShell }} "{{ loginShell }}"
+{%- endfor %}
+    - require:
+      - cmd: PBIS-installsh
+
+PBIS-config-uHome:
+  cmd.run:
+    - name: |
+{%- for uHome in pbisUserHome %}
+        {{ pbisBinDir }}/bin/config {{ uHome }} "{{ loginHome }}"
+{%- endfor %}
+    - require:
+      - cmd: PBIS-installsh

--- a/join-domain/elx/pbis.sls
+++ b/join-domain/elx/pbis.sls
@@ -35,12 +35,11 @@
 # PBIS config items:
 # DomainManagerIgnoreAllTrusts "false" (default)
 # DomainManagerIncludeTrustsList "" (default)
-# HomeDirTemplate "%H/local/%D/%U" (default)
-# Local_HomeDirTemplate "%H/local/%D/%U" (default)
 # LoginShellTemplate "/bin/sh" (default)
 # Local_LoginShellTemplate "/bin/sh" (default)
-{%- set pbisUserHome = 'HomeDirTemplate, Local_HomeDirTemplate' %}
+{%- set pbisUserHome = [ 'HomeDirTemplate', 'Local_HomeDirTemplate' ] %}
 {%- set pbisUserShell = [ 'LoginShellTemplate', 'Local_LoginShellTemplate' ] %}
+{%- set loginHome = '%H/%D/%U' %}
 {%- set loginShell = '/bin/bash' %}
 
 
@@ -70,7 +69,16 @@ PBIS-config-iShell:
   cmd.run:
     - name: |
 {%- for userShell in pbisUserShell %}
-        {{ pbisBinDir }}/bin/config {{ userShell }} "/bin/bash"
+        {{ pbisBinDir }}/bin/config {{ userShell }} "{{ loginShell }}"
+{%- endfor %}
+    - require:
+      - cmd: PBIS-installsh
+
+PBIS-config-uHome:
+  cmd.run:
+    - name: |
+{%- for uHome in pbisUserHome %}
+        {{ pbisBinDir }}/bin/config {{ uHome }} "{{ loginHome }}"
 {%- endfor %}
     - require:
       - cmd: PBIS-installsh


### PR DESCRIPTION
- Sets user home dir param
- Sets user interactive shell param
- Ignores other domains in multi-domain forest
- Sets domain trust to only the explicitly-joined domain